### PR TITLE
Ignore disabled formatters on lookup

### DIFF
--- a/format.py
+++ b/format.py
@@ -48,7 +48,7 @@ class FormatListener(EventListener):
 
     def on_pre_save(self, view: View) -> None:
         formatter = registry.lookup(view, view_scope(view))
-        if formatter and formatter.enabled and formatter.format_on_save:
+        if formatter and formatter.format_on_save:
             view.run_command("format_file")
 
 
@@ -58,11 +58,10 @@ class FormatFileCommand(TextCommand):
             return
 
         if formatter := registry.lookup(self.view, view_scope(self.view)):
-            if formatter.enabled:
-                try:
-                    formatter.format(self.view, edit, region)
-                except Exception as err:
-                    print("[Format]", err)
+            try:
+                formatter.format(self.view, edit, region)
+            except Exception as err:
+                print("[Format]", err)
         else:
             print("[Format]", "No formatter for file")
 
@@ -78,11 +77,10 @@ class FormatSelectionCommand(TextCommand):
 
             scope = self.view.scope_name(region.begin())
             if formatter := registry.lookup(self.view, scope):
-                if formatter.enabled:
-                    try:
-                        formatter.format(self.view, edit, region)
-                    except Exception as err:
-                        print("[Format]", err)
+                try:
+                    formatter.format(self.view, edit, region)
+                except Exception as err:
+                    print("[Format]", err)
             else:
                 print("[Format]", "No formatter for selection")
 

--- a/plugin/formatter.py
+++ b/plugin/formatter.py
@@ -20,17 +20,14 @@ class Formatter:
         return self._name
 
     @property
-    def enabled(self) -> bool:
-        return self._settings.enabled
-
-    @property
     def format_on_save(self) -> bool:
         return self._settings.format_on_save
 
     def score(self, scope: str) -> int:
         return (
             score_selector(scope, selector)
-            if (selector := self._settings.selector) is not None
+            if self._settings.enabled
+            and (selector := self._settings.selector) is not None
             else -1
         )
 


### PR DESCRIPTION
This effectively adds support for multiple formatters with the same selector by skipping a formatter if it is disabled in User or Project settings.