### PR TITLE
Use correct hierarchy when merging formatter, project and settings

### DIFF
--- a/format.py
+++ b/format.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sublime import active_window, status_message
+from sublime import active_window, status_message, windows
 from sublime import Edit, View, Window
 from sublime_plugin import ApplicationCommand, EventListener, TextCommand
 from typing import cast, Optional
@@ -21,7 +21,7 @@ registry: FormatterRegistry = cast(FormatterRegistry, None)
 def plugin_loaded():
     global registry
     registry = FormatterRegistry()
-    registry.startup()
+    registry.startup(windows=windows())
 
 
 def plugin_unloaded():
@@ -31,14 +31,6 @@ def plugin_unloaded():
 
 
 class FormatListener(EventListener):
-    def on_init(self, views: list[View]) -> None:
-        for view in views:
-            if window := view.window():
-                registry.register(window)
-
-    def on_exit(self) -> None:
-        registry.teardown()
-
     def on_new_window_async(self, window: Window) -> None:
         registry.register(window)
 

--- a/format.py
+++ b/format.py
@@ -114,9 +114,9 @@ class FormatToggleEnabledCommand(ApplicationCommand):
 class FormatManageEnabledCommand(ApplicationCommand):
     def run(self, enable: bool) -> None:
         items = [
-            formatter_settings.name
-            for formatter_settings in registry.settings.formatters()
-            if formatter_settings.enabled != enable
+            name
+            for name, settings in registry.settings.formatters().items()
+            if settings.enabled != enable
         ]
 
         def toggle_enabled(selection: int) -> None:
@@ -144,9 +144,9 @@ class FormatToggleFormatOnSaveCommand(ApplicationCommand):
 class FormatManageFormatOnSaveCommand(ApplicationCommand):
     def run(self, enable: bool) -> None:
         items = [
-            formatter_settings.name
-            for formatter_settings in registry.settings.formatters()
-            if formatter_settings.format_on_save != enable
+            name
+            for name, settings in registry.settings.formatters().items()
+            if settings.format_on_save != enable
         ]
 
         def toggle_format_on_save(selection: int) -> None:

--- a/format.py
+++ b/format.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sublime import active_window, status_message, windows
+from sublime import active_window, status_message
 from sublime import Edit, View, Window
 from sublime_plugin import ApplicationCommand, EventListener, TextCommand
 from typing import cast, Optional
@@ -21,7 +21,7 @@ registry: FormatterRegistry = cast(FormatterRegistry, None)
 def plugin_loaded():
     global registry
     registry = FormatterRegistry()
-    registry.startup(windows=windows())
+    registry.startup()
 
 
 def plugin_unloaded():
@@ -31,6 +31,11 @@ def plugin_unloaded():
 
 
 class FormatListener(EventListener):
+    def on_init(self, views: list[View]) -> None:
+        for view in views:
+            if window := view.window():
+                registry.register(window)
+
     def on_new_window_async(self, window: Window) -> None:
         registry.register(window)
 

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -4,10 +4,11 @@ from .registry import FormatterRegistry, WindowFormatterRegistry
 from .settings import (
     FormatSettings,
     FormatterSettings,
-    ProjectFormatSettings,
-    ProjectFormatterSettings,
+    ProjectSettings,
+    MergedSettings,
     Setting,
     Settings,
+    TopLevelSettings,
 )
 from .shell import shell
 from .view import extract_variables, view_region, view_scope

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -6,6 +6,7 @@ from .settings import (
     FormatterSettings,
     ProjectSettings,
     MergedSettings,
+    Setting,
     Settings,
     TopLevelSettings,
 )

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -6,7 +6,7 @@ from .settings import (
     FormatterSettings,
     ProjectSettings,
     MergedSettings,
-    Setting,
+    SettingKey,
     Settings,
     TopLevelSettings,
 )

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -6,7 +6,6 @@ from .settings import (
     FormatterSettings,
     ProjectSettings,
     MergedSettings,
-    Setting,
     Settings,
     TopLevelSettings,
 )

--- a/plugin/registry.py
+++ b/plugin/registry.py
@@ -9,7 +9,7 @@ from .settings import (
     FormatterSettings,
     MergedSettings,
     ProjectSettings,
-    Setting,
+    SettingKey,
     Settings,
 )
 
@@ -117,7 +117,7 @@ class CachedSettings(Settings):
         self._cached_settings.update(
             {
                 setting.value: value
-                for setting in Setting
+                for setting in SettingKey
                 if (value := self._settings.get(setting.value)) is not None
             }
         )

--- a/plugin/registry.py
+++ b/plugin/registry.py
@@ -17,10 +17,8 @@ class FormatterRegistry:
         self.settings = FormatSettings()
         self._window_registries: dict[int, WindowFormatterRegistry] = {}
 
-    def startup(self, windows: list[Window]) -> None:
+    def startup(self) -> None:
         self.settings.add_on_change("update_registry", self.update)
-        for window in windows:
-            self.register(window)
 
     def teardown(self) -> None:
         self.settings.clear_on_change("update_registry")

--- a/plugin/registry.py
+++ b/plugin/registry.py
@@ -17,9 +17,10 @@ class FormatterRegistry:
         self.settings = FormatSettings()
         self._window_registries: dict[int, WindowFormatterRegistry] = {}
 
-    def startup(self) -> None:
+    def startup(self, windows: list[Window]) -> None:
         self.settings.add_on_change("update_registry", self.update)
-        self.update()
+        for window in windows:
+            self.register(window)
 
     def teardown(self) -> None:
         self.settings.clear_on_change("update_registry")

--- a/plugin/registry.py
+++ b/plugin/registry.py
@@ -100,7 +100,7 @@ class CachedSettings(Settings):
     def __init__(self, settings: Settings) -> None:
         self._settings = settings
         self._cached_settings: dict[str, Any] = {
-            setting.key: settings.get(*setting.value) for setting in Setting
+            setting.value: settings.get(setting.value) for setting in Setting
         }
 
     def get(self, key: str, default: Any = None) -> Any:
@@ -112,5 +112,5 @@ class CachedSettings(Settings):
 
     def reload(self) -> None:
         self._cached_settings.update(
-            {setting.key: self._settings.get(*setting.value) for setting in Setting}
+            {setting.value: self._settings.get(setting.value) for setting in Setting}
         )

--- a/plugin/settings.py
+++ b/plugin/settings.py
@@ -1,19 +1,9 @@
 from __future__ import annotations
 
-from enum import Enum
 from sublime import load_settings, save_settings, Window
 from typing import Any, Callable, Protocol
 
 from .error import ErrorStyle
-
-
-class Setting(Enum):
-    SELECTOR = "selector"
-    CMD = "cmd"
-    ENABLED = "enabled"
-    FORMAT_ON_SAVE = "format_on_save"
-    ERROR_STYLE = "error_style"
-    TIMEOUT = "timeout"
 
 
 class Settings(Protocol):
@@ -27,34 +17,34 @@ class Settings(Protocol):
 
     @property
     def selector(self) -> str:
-        return self.get(Setting.SELECTOR.value)
+        return self.get("selector")
 
     @property
     def cmd(self) -> list[str]:
-        return self.get(Setting.CMD.value)
+        return self.get("cmd")
 
     @property
     def enabled(self) -> bool:
-        return self.get(Setting.ENABLED.value)
+        return self.get("enabled")
 
     def set_enabled(self, enabled: bool) -> None:
-        return self.set(Setting.ENABLED.value, enabled)
+        return self.set("enabled", enabled)
 
     @property
     def format_on_save(self) -> bool:
-        return self.get(Setting.FORMAT_ON_SAVE.value)
+        return self.get("format_on_save")
 
     def set_format_on_save(self, enabled: bool) -> None:
-        return self.set(Setting.FORMAT_ON_SAVE.value, enabled)
+        return self.set("format_on_save", enabled)
 
     @property
     def error_style(self) -> ErrorStyle:
-        value = self.get(Setting.ERROR_STYLE.value)
+        value = self.get("error_style")
         return next((style for style in ErrorStyle if style.value == value))
 
     @property
     def timeout(self) -> int:
-        return self.get(Setting.TIMEOUT.value)
+        return self.get("timeout")
 
 
 class TopLevelSettings(Settings, Protocol):

--- a/plugin/settings.py
+++ b/plugin/settings.py
@@ -120,5 +120,5 @@ class MergedSettings(Settings):
         )
 
     def set(self, key: str, value: Any) -> None:
-        if (source := next((source for source in self.all))) is not None:
+        if source := next(iter(self.all), None):
             source.set(key, value)

--- a/plugin/settings.py
+++ b/plugin/settings.py
@@ -50,7 +50,10 @@ class Settings(Protocol):
     @property
     def error_style(self) -> ErrorStyle:
         value = self.get(Setting.ERROR_STYLE.value)
-        return next((style for style in ErrorStyle if style.value == value))
+        return next(
+            (style for style in ErrorStyle if style.value == value),
+            ErrorStyle.PANEL,
+        )
 
     @property
     def timeout(self) -> int:

--- a/plugin/settings.py
+++ b/plugin/settings.py
@@ -8,18 +8,12 @@ from .error import ErrorStyle
 
 
 class Setting(Enum):
-    SELECTOR = "selector", None
-    CMD = "cmd", None
-    ENABLED = "enabled", True
-    FORMAT_ON_SAVE = "format_on_save", False
-    ERROR_STYLE = "error_style", "panel"
-    TIMEOUT = "timeout", 60
-
-    __slots__ = ["key", "default"]
-
-    def __init__(self, key: str, default: Any):
-        self.key = key
-        self.default = default
+    SELECTOR = "selector"
+    CMD = "cmd"
+    ENABLED = "enabled"
+    FORMAT_ON_SAVE = "format_on_save"
+    ERROR_STYLE = "error_style"
+    TIMEOUT = "timeout"
 
 
 class Settings(Protocol):
@@ -33,37 +27,34 @@ class Settings(Protocol):
 
     @property
     def selector(self) -> str:
-        return self.get(*Setting.SELECTOR.value)
+        return self.get(Setting.SELECTOR.value)
 
     @property
     def cmd(self) -> list[str]:
-        return self.get(*Setting.CMD.value)
+        return self.get(Setting.CMD.value)
 
     @property
     def enabled(self) -> bool:
-        return self.get(*Setting.ENABLED.value)
+        return self.get(Setting.ENABLED.value)
 
     def set_enabled(self, enabled: bool) -> None:
-        return self.set(Setting.ENABLED.key, enabled)
+        return self.set(Setting.ENABLED.value, enabled)
 
     @property
     def format_on_save(self) -> bool:
-        return self.get(*Setting.FORMAT_ON_SAVE.value)
+        return self.get(Setting.FORMAT_ON_SAVE.value)
 
     def set_format_on_save(self, enabled: bool) -> None:
-        return self.set(Setting.FORMAT_ON_SAVE.key, enabled)
+        return self.set(Setting.FORMAT_ON_SAVE.value, enabled)
 
     @property
     def error_style(self) -> ErrorStyle:
-        value = self.get(*Setting.ERROR_STYLE.value)
-        return next(
-            (style for style in ErrorStyle if style.value == value),
-            ErrorStyle.PANEL,
-        )
+        value = self.get(Setting.ERROR_STYLE.value)
+        return next((style for style in ErrorStyle if style.value == value))
 
     @property
     def timeout(self) -> int:
-        return self.get(*Setting.TIMEOUT.value)
+        return self.get(Setting.TIMEOUT.value)
 
 
 class FormatSettings(Settings):

--- a/plugin/settings.py
+++ b/plugin/settings.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Protocol
 from .error import ErrorStyle
 
 
-class Setting(Enum):
+class SettingKey(Enum):
     SELECTOR = "selector"
     CMD = "cmd"
     ENABLED = "enabled"
@@ -27,29 +27,29 @@ class Settings(Protocol):
 
     @property
     def selector(self) -> str:
-        return self.get(Setting.SELECTOR.value)
+        return self.get(SettingKey.SELECTOR.value)
 
     @property
     def cmd(self) -> list[str]:
-        return self.get(Setting.CMD.value)
+        return self.get(SettingKey.CMD.value)
 
     @property
     def enabled(self) -> bool:
-        return self.get(Setting.ENABLED.value)
+        return self.get(SettingKey.ENABLED.value)
 
     def set_enabled(self, enabled: bool) -> None:
-        return self.set(Setting.ENABLED.value, enabled)
+        return self.set(SettingKey.ENABLED.value, enabled)
 
     @property
     def format_on_save(self) -> bool:
-        return self.get(Setting.FORMAT_ON_SAVE.value)
+        return self.get(SettingKey.FORMAT_ON_SAVE.value)
 
     def set_format_on_save(self, enabled: bool) -> None:
-        return self.set(Setting.FORMAT_ON_SAVE.value, enabled)
+        return self.set(SettingKey.FORMAT_ON_SAVE.value, enabled)
 
     @property
     def error_style(self) -> ErrorStyle:
-        value = self.get(Setting.ERROR_STYLE.value)
+        value = self.get(SettingKey.ERROR_STYLE.value)
         return next(
             (style for style in ErrorStyle if style.value == value),
             ErrorStyle.PANEL,
@@ -57,7 +57,7 @@ class Settings(Protocol):
 
     @property
     def timeout(self) -> int:
-        return self.get(Setting.TIMEOUT.value)
+        return self.get(SettingKey.TIMEOUT.value)
 
 
 class TopLevelSettings(Settings, Protocol):

--- a/plugin/settings.py
+++ b/plugin/settings.py
@@ -1,9 +1,19 @@
 from __future__ import annotations
 
+from enum import Enum
 from sublime import load_settings, save_settings, Window
 from typing import Any, Callable, Protocol
 
 from .error import ErrorStyle
+
+
+class Setting(Enum):
+    SELECTOR = "selector"
+    CMD = "cmd"
+    ENABLED = "enabled"
+    FORMAT_ON_SAVE = "format_on_save"
+    ERROR_STYLE = "error_style"
+    TIMEOUT = "timeout"
 
 
 class Settings(Protocol):
@@ -17,34 +27,34 @@ class Settings(Protocol):
 
     @property
     def selector(self) -> str:
-        return self.get("selector")
+        return self.get(Setting.SELECTOR.value)
 
     @property
     def cmd(self) -> list[str]:
-        return self.get("cmd")
+        return self.get(Setting.CMD.value)
 
     @property
     def enabled(self) -> bool:
-        return self.get("enabled")
+        return self.get(Setting.ENABLED.value)
 
     def set_enabled(self, enabled: bool) -> None:
-        return self.set("enabled", enabled)
+        return self.set(Setting.ENABLED.value, enabled)
 
     @property
     def format_on_save(self) -> bool:
-        return self.get("format_on_save")
+        return self.get(Setting.FORMAT_ON_SAVE.value)
 
     def set_format_on_save(self, enabled: bool) -> None:
-        return self.set("format_on_save", enabled)
+        return self.set(Setting.FORMAT_ON_SAVE.value, enabled)
 
     @property
     def error_style(self) -> ErrorStyle:
-        value = self.get("error_style")
+        value = self.get(Setting.ERROR_STYLE.value)
         return next((style for style in ErrorStyle if style.value == value))
 
     @property
     def timeout(self) -> int:
-        return self.get("timeout")
+        return self.get(Setting.TIMEOUT.value)
 
 
 class TopLevelSettings(Settings, Protocol):


### PR DESCRIPTION
This updates the mechanism in which the settings from the plugin settings, project settings, and formatter settings are merged into a proper hierarchy.

The default values for the settings have also been removed as it doesn't make sense to define them twice.