### PR TITLE
Register formatters per view instead of window

### DIFF
--- a/format.py
+++ b/format.py
@@ -38,6 +38,9 @@ class FormatListener(EventListener):
     def on_new_async(self, view: View) -> None:
         registry.register(view)
 
+    def on_load_async(self, view: View) -> None:
+        registry.register(view)
+
     def on_close(self, view: View) -> None:
         registry.unregister(view)
 

--- a/format.py
+++ b/format.py
@@ -42,10 +42,12 @@ class FormatListener(EventListener):
         registry.unregister(view)
 
     def on_load_project_async(self, window: Window) -> None:
-        registry.update_window(window)
+        for view in window.views():
+            registry.update(view)
 
     def on_post_save_project_async(self, window: Window) -> None:
-        registry.update_window(window)
+        for view in window.views():
+            registry.update(view)
 
     def on_pre_save(self, view: View) -> None:
         formatter = registry.lookup(view, view_scope(view))

--- a/format.py
+++ b/format.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sublime import active_window, set_timeout_async, status_message
+from sublime import active_window, status_message
 from sublime import Edit, View, Window
 from sublime_plugin import ApplicationCommand, EventListener, TextCommand
 from typing import cast
@@ -32,11 +32,8 @@ def plugin_unloaded():
 
 class FormatListener(EventListener):
     def on_init(self, views: list[View]) -> None:
-        def register_views():
-            for view in views:
-                registry.register(view)
-
-        set_timeout_async(register_views)
+        for view in views:
+            registry.register(view)
 
     def on_new_async(self, view: View) -> None:
         registry.register(view)

--- a/format.py
+++ b/format.py
@@ -32,18 +32,17 @@ def plugin_unloaded():
 
 class FormatListener(EventListener):
     def on_init(self, views: list[View]) -> None:
-        def register_windows():
+        def register_views():
             for view in views:
-                if window := view.window():
-                    registry.register(window)
+                registry.register(view)
 
-        set_timeout_async(register_windows)
+        set_timeout_async(register_views)
 
-    def on_new_window_async(self, window: Window) -> None:
-        registry.register(window)
+    def on_new_async(self, view: View) -> None:
+        registry.register(view)
 
-    def on_pre_close_window(self, window: Window) -> None:
-        registry.unregister(window)
+    def on_close(self, view: View) -> None:
+        registry.unregister(view)
 
     def on_load_project_async(self, window: Window) -> None:
         registry.update_window(window)

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -8,6 +8,7 @@ from .settings import (
     MergedSettings,
     Settings,
     TopLevelSettings,
+    ViewSettings,
 )
 from .shell import shell
 from .view import extract_variables, view_region, view_scope

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -1,6 +1,6 @@
 from .error import ErrorStyle, FormatError, display_error, clear_error
 from .formatter import Formatter
-from .registry import FormatterRegistry, WindowFormatterRegistry
+from .registry import FormatterRegistry, ViewFormatterRegistry
 from .settings import (
     FormatSettings,
     FormatterSettings,

--- a/plugin/formatter.py
+++ b/plugin/formatter.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sublime import expand_variables, score_selector
+from sublime import expand_variables
 from sublime import Edit, Region, View
 
 import os
@@ -17,14 +17,6 @@ class Formatter:
     def __init__(self, name: str, settings: Settings):
         self.name: str = name
         self.settings: Settings = settings
-
-    def score(self, scope: str) -> int:
-        return (
-            score_selector(scope, selector)
-            if self.settings.enabled
-            and (selector := self.settings.selector) is not None
-            else -1
-        )
 
     def format(self, view: View, edit: Edit, region: Region) -> None:
         text = view.substr(region)

--- a/plugin/registry.py
+++ b/plugin/registry.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sublime import score_selector, View, Window
+from sublime import score_selector, View
 
 from .formatter import Formatter
 from .settings import CachedSettings, FormatSettings, MergedSettings, ViewSettings
@@ -27,13 +27,12 @@ class FormatterRegistry:
         if (view_id := view.id()) in self._view_registries:
             del self._view_registries[view_id]
 
-    def update(self) -> None:
-        for view_registry in self._view_registries.values():
-            view_registry.update()
-
-    def update_window(self, window: Window) -> None:
-        for view in window.views():
+    def update(self, view: View | None = None) -> None:
+        if view is not None:
             if view_registry := self._view_registries.get(view.id()):
+                view_registry.update()
+        else:
+            for view_registry in self._view_registries.values():
                 view_registry.update()
 
     def lookup(self, view: View, scope: str) -> Formatter | None:

--- a/plugin/registry.py
+++ b/plugin/registry.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sublime import score_selector, set_timeout_async, View, Window
+from sublime import score_selector, View, Window
 
 from .formatter import Formatter
 from .settings import CachedSettings, FormatSettings, MergedSettings, ViewSettings
@@ -12,10 +12,7 @@ class FormatterRegistry:
         self._view_registries: dict[int, ViewFormatterRegistry] = {}
 
     def startup(self) -> None:
-        self.settings.add_on_change(
-            "update_registry",
-            lambda: set_timeout_async(self.update),
-        )
+        self.settings.add_on_change("update_registry", self.update)
 
     def teardown(self) -> None:
         self.settings.clear_on_change("update_registry")

--- a/plugin/registry.py
+++ b/plugin/registry.py
@@ -50,6 +50,9 @@ class ViewFormatterRegistry:
         self._lookup_cache: dict[str, Formatter] = {}
 
     def update(self) -> None:
+        for formatter in self._lookup_cache.values():
+            formatter.settings.invalidate()
+
         self._lookup_cache.clear()
 
     def lookup(self, scope: str) -> Formatter | None:

--- a/plugin/settings.py
+++ b/plugin/settings.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sublime import load_settings, save_settings, Window
+from sublime import load_settings, save_settings, View, Window
 from typing import Any, Callable, Protocol
 
 from .error import ErrorStyle
@@ -108,6 +108,28 @@ class ProjectSettings(TopLevelSettings):
         return {
             key: value
             for key, value in project.get("settings", {}).get("Format", {}).items()
+            if key != "formatters"
+        }
+
+
+class ViewSettings(TopLevelSettings):
+    __slots__ = ["view"]
+
+    def __init__(self, view: View) -> None:
+        self.view = view
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self.view.settings().get("Format", {}).get(key, default)
+
+    def set(self, key: str, value: Any) -> None:
+        settings = self.view.settings().setdefault("Format", {})
+        settings[key] = value
+        self.view.settings()["Format"] = settings
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            key: value
+            for key, value in self.view.settings().to_dict().items()
             if key != "formatters"
         }
 

--- a/plugin/settings.py
+++ b/plugin/settings.py
@@ -143,21 +143,24 @@ class MergedSettings(Settings):
 
 
 class CachedSettings(Settings):
-    __slots__ = ["_settings", "_settings_cache"]
+    __slots__ = ["settings", "_cache"]
 
     def __init__(self, settings: Settings) -> None:
-        self._settings = settings
-        self._settings_cache: dict[str, Any] = {}
+        self.settings = settings
+        self._cache: dict[str, Any] = {}
 
     def get(self, key: str, default: Any = None) -> Any:
-        if key in self._settings_cache:
-            return self._settings_cache[key]
+        if key in self._cache:
+            return self._cache[key]
 
-        value = self._settings.get(key, default)
-        self._settings_cache[key] = value
+        value = self.settings.get(key, default)
+        self._cache[key] = value
 
         return value
 
     def set(self, key: str, value: Any) -> None:
-        self._settings.set(key, value)
-        self._settings_cache[key] = value
+        self.settings.set(key, value)
+        self._cache[key] = value
+
+    def invalidate(self) -> None:
+        self._cache.clear()


### PR DESCRIPTION
Registering per view allows us to make use of `view.settings()` instead of loading a project from the window.