### PR TITLE
Remove unnecessary merging of fallback settings

### DIFF
--- a/plugin/registry.py
+++ b/plugin/registry.py
@@ -101,8 +101,6 @@ class ScopedFormatterRegistry:
                 MergedSettings(
                     self.scoped_settings.formatter(matched_formatter),
                     self.settings.formatter(matched_formatter),
-                    self.scoped_settings,
-                    self.settings,
                 ),
             ),
         )


### PR DESCRIPTION
The top level fallback for both scope and global settings are already included in the `.formatter(name)` method, so there is no need to include them again in the final merged settings provided to the formatter.