### PR TITLE
Match selectors defined in both global and view settings

### DIFF
--- a/plugin/registry.py
+++ b/plugin/registry.py
@@ -48,23 +48,16 @@ class FormatterRegistry:
             del self._cache[view_id]
 
         view_settings = ViewSettings(view)
-        merged_formatters = {
-            **self.settings.get("formatters", {}),
-            **view_settings.get("formatters", {}),
-        }
 
-        if not merged_formatters:
-            cache(scope)
-            return None
+        formatter_selectors = {
+            **self.settings.selectors(),
+            **view_settings.selectors(),
+        }
 
         max_score: int = 0
         matched_formatter: str | None = None
-        for name, settings in merged_formatters.items():
-            if (selector := settings.get("selector")) is None:
-                continue
-
-            score = score_selector(scope, selector)
-            if score > max_score:
+        for name, selector in formatter_selectors.items():
+            if (score := score_selector(scope, selector)) > max_score:
                 max_score = score
                 matched_formatter = name
 

--- a/plugin/settings.py
+++ b/plugin/settings.py
@@ -59,6 +59,13 @@ class TopLevelSettings(Settings, Protocol):
     def formatter(self, name: str) -> Settings:
         return MergedSettings(FormatterSettings(name, settings=self), self)
 
+    def selectors(self) -> dict[str, str]:
+        return {
+            name: selector
+            for name, settings in self.get("formatters", {}).items()
+            if (selector := settings.get("selector")) is not None
+        }
+
 
 class FormatSettings(TopLevelSettings):
     def __init__(self) -> None:


### PR DESCRIPTION
This ensures that regardless of whether formatter settings are overridden in view settings, the selector will still be used from global settings if not defined for the view settings.