### PR TITLE
Remove formatter settings caching

### DIFF
--- a/plugin/formatter.py
+++ b/plugin/formatter.py
@@ -12,10 +12,11 @@ from .view import extract_variables
 
 
 class Formatter:
-    __slots__ = ["name", "settings"]
+    __slots__ = ["name", "selector", "settings"]
 
-    def __init__(self, name: str, settings: Settings):
+    def __init__(self, name: str, selector: str, settings: Settings):
         self.name: str = name
+        self.selector: str = selector
         self.settings: Settings = settings
 
     def format(self, view: View, edit: Edit, region: Region) -> None:

--- a/plugin/registry.py
+++ b/plugin/registry.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from sublime import score_selector, View, Window
 
 from .formatter import Formatter
-from .settings import CachedSettings, FormatSettings, MergedSettings, ViewSettings
+from .settings import FormatSettings, MergedSettings, ViewSettings
 
 
 class FormatterRegistry:
@@ -60,11 +60,9 @@ class FormatterRegistry:
         formatter = (
             Formatter(
                 name=matched_formatter,
-                settings=CachedSettings(
-                    MergedSettings(
-                        view_settings.formatter(matched_formatter),
-                        self.settings.formatter(matched_formatter),
-                    ),
+                settings=MergedSettings(
+                    view_settings.formatter(matched_formatter),
+                    self.settings.formatter(matched_formatter),
                 ),
             )
             if matched_formatter is not None

--- a/plugin/registry.py
+++ b/plugin/registry.py
@@ -35,7 +35,7 @@ class FormatterRegistry:
 
         if is_view_scope and (formatter := self._cache.get(view_id)) is not None:
             if isinstance(formatter, Formatter):
-                if score_selector(scope, formatter.settings.selector) > 0:
+                if score_selector(scope, formatter.selector) > 0:
                     return formatter
             elif isinstance(formatter, str):
                 if scope == formatter:
@@ -60,6 +60,7 @@ class FormatterRegistry:
         formatter = (
             Formatter(
                 name=matched_formatter,
+                selector=formatter_selectors[matched_formatter],
                 settings=MergedSettings(
                     view_settings.formatter(matched_formatter),
                     self.settings.formatter(matched_formatter),

--- a/plugin/settings.py
+++ b/plugin/settings.py
@@ -149,27 +149,3 @@ class MergedSettings(Settings):
     def set(self, key: str, value: Any) -> None:
         if source := next(iter(self.all), None):
             source.set(key, value)
-
-
-class CachedSettings(Settings):
-    __slots__ = ["settings", "_cache"]
-
-    def __init__(self, settings: Settings) -> None:
-        self.settings = settings
-        self._cache: dict[str, Any] = {}
-
-    def get(self, key: str, default: Any = None) -> Any:
-        if key in self._cache:
-            return self._cache[key]
-
-        value = self.settings.get(key, default)
-        self._cache[key] = value
-
-        return value
-
-    def set(self, key: str, value: Any) -> None:
-        self.settings.set(key, value)
-        self._cache[key] = value
-
-    def invalidate(self) -> None:
-        self._cache.clear()


### PR DESCRIPTION
This allows for an unsaved project to be modified or settings to be explicitly set on the view, and for them to take effect if the view has already been looked up.