### PR TITLE
Include license and readme in Sublime package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Create Sublime package
-        run: zip -r Format.sublime-package . -x ".git/*" ".github/*" .gitignore .editorconfig LICENSE README.md
+        run: zip -r Format.sublime-package . -x ".git/*" ".github/*" .gitignore .editorconfig
 
       - name: Release
         uses: softprops/action-gh-release@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.sublime-workspace
 *.sublime-project
+.ruff_cache

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To find the scope at a given position, go to: Menu → Tools → Developer → S
 
 1. Select the `Settings > Browse Packages…` menu item
 2. Browse up a directory and then into the `Installed Packages/` directory
-3. Download [`Format.sublime-package`](https://github.com/Rypac/sublime-format/releases/download/latest/Format.sublime-package) and copy it into the `Installed Packages/` directory
+3. Download [`Format.sublime-package`](https://github.com/Rypac/sublime-format/releases/latest/download/Format.sublime-package) and copy it into the `Installed Packages/` directory
 
 ### Clone Repository
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For example, this is the configuration for the formatting of Haskell and Rust so
 {
     "formatters": {
         "Haskell": {
-            "command": ["fourmolu", "--indentation", "$tab_size", "--stdin-input-file", "-"],
+            "command": ["fourmolu", "--indentation", "$tab_size", "--stdin-input-file", "$file"],
             "selector": "source.haskell"
         },
         "Rust": {


### PR DESCRIPTION
Includes additional files in `Format.sublime-package` generated for a release and updates documentation.