### PR TITLE
Fix invalid method call when invalidating window

### DIFF
--- a/plugin/registry.py
+++ b/plugin/registry.py
@@ -27,7 +27,7 @@ class FormatterRegistry:
 
     def invalidate_window(self, window: Window) -> None:
         for view in window.views():
-            self.unregister(view)
+            self.invalidate_view(view)
 
     def lookup(self, view: View, scope: str) -> Formatter | None:
         view_id = view.id()


### PR DESCRIPTION
The `unregister` method was renamed to `invalidate_view`, however that was not updated in `invalidate_window`.